### PR TITLE
Fix ncurses color

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -265,8 +265,26 @@ else
         WITHOUT_ANSI=1
         DRV_CURSES=1
     else
-        echo "No"
-        WITHOUT_CURSES=1
+        echo "#include <ncurses.h>" > .tmp.c
+        echo "int main(void) { initscr(); endwin(); return 0; }" >> .tmp.c
+
+        TMP_CFLAGS="-I/usr/local/include -I/usr/include/ncurses -I/usr/include/ncursesw"
+        TMP_LDFLAGS="-L/usr/local/lib -lncurses"
+
+        $CC $CFLAGS $TMP_CFLAGS .tmp.c $TMP_LDFLAGS -o .tmp.o 2>> .config.log
+        if [ $? = 0 ] ; then
+            echo "#define CONFOPT_CURSES 1" >> config.h
+            echo $TMP_CFLAGS >> config.cflags
+            echo $TMP_LDFLAGS >> config.ldflags
+            echo "OK (ncurses)"
+            DRIVERS="ncursesw $DRIVERS"
+            DRV_OBJS="mpv_curses.o $DRV_OBJS"
+            WITHOUT_ANSI=1
+            DRV_CURSES=1
+        else
+            echo "No"
+            WITHOUT_CURSES=1
+        fi
     fi
 fi
 

--- a/mp_tui.mpsl
+++ b/mp_tui.mpsl
@@ -817,11 +817,11 @@ sub mp_drv.menu()
             }
         }
 
-        mp.tui.attr(mp.color.normal.attr);
+        mp.tui.attr(mp.colors.normal.attr);
         mp.tui.draw(mp.active(), 0);
     }
 
-    mp.tui.attr(mp.color.normal.attr);
+    mp.tui.attr(mp.colors.normal.attr);
 
     if (action != NULL)
         mp.process_action(action);

--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -650,6 +650,7 @@ static mpdm_t nc_tui_doc_draw(mpdm_t args, mpdm_t ctxt)
             s = mpdm_aget(l, m);
 
             wattrset(stdscr, nc_attrs[attr]);
+            wattron(stdscr, nc_attrs[attr]);
             nc_addwstr(s);
         }
     }
@@ -805,6 +806,7 @@ static mpdm_t nc_tui_attr(mpdm_t a, mpdm_t ctxt)
 static mpdm_t nc_tui_refresh(mpdm_t a, mpdm_t ctxt)
 /* TUI: refresh the screen */
 {
+
     wrefresh(stdscr);
     return NULL;
 }


### PR DESCRIPTION
The current build with ncurses does not display any colors since the attributes were never set to on (via wattron function).
Also, while drawing the menu, all edited text was underlined because `mp_tui` refered to unknown color attribute (which happened to be "underline" on my version). 

Fixed both issues and checked it does not break ANSI version. 