### PR TITLE
Fix build issue

### DIFF
--- a/mpv_curses.c
+++ b/mpv_curses.c
@@ -733,6 +733,13 @@ static void nc_build_colors(void)
                 cp |= A_REVERSE;
             if (mpdm_seek_wcs(w, L"underline", 1) != -1)
                 cp |= A_UNDERLINE;
+
+#ifndef A_ITALIC
+
+/* For very old ncurses version ( < 2013/08 ) */ 
+#define A_ITALIC 0
+
+#endif
             if (mpdm_seek_wcs(w, L"italic", 1) != -1)
                 cp |= A_ITALIC;
     


### PR DESCRIPTION
There was a remark from Claire that the previous PR introducing bright color instead of bold color was not working correctly (not even compiling) on OpenBSD. This PR should fix both issue.

1. It defines a default A_ITALIC to 0 if it's not defined so the code can build on OpenBSD old ncurses version
2. It detects the terminal feature for the ansi version, so if bright colors are not supported, it fallbacks to bold as it was done previously.

@ttcdt Please assert it fixed your issue and comment, thanks!