### PR TITLE
gcc14 wants another #include in mpdm/config.sh

### DIFF
--- a/mpdm/config.sh
+++ b/mpdm/config.sh
@@ -396,6 +396,7 @@ fi
 # mkdir() with 2 arguments detection
 echo -n "Testing for number of arguments for mkdir()... "
 echo "#include <unistd.h>" > .tmp.c
+echo "#include <sys/stat.h>" > .tmp.c
 echo "int main(void) { mkdir(\"dummy\", 0755); }" >> .tmp.c
 
 $CC $CFLAGS .tmp.c -o .tmp.o 2>> .config.log


### PR DESCRIPTION
mkdir() is declared in sys/stat.h -- without the #include in mpdm/config.sh, the number of arguments to mkdir()  comes out wrong, i.e., CONFOPT_MKDIR_MODE is undefined, and gcc14 fails to compile mpdm/mpdm_f.c